### PR TITLE
Update base image and queuemanager version to 9.2.3.0-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM cp.icr.io/cp/ibm-mqadvanced-server-integration@sha256:cfe3a4cec7a353e7496d367f9789dbe21fbf60dac46f127d288dda329560d13a
+FROM cp.icr.io/cp/ibm-mqadvanced-server-integration@sha256:e527f7279954a0abd9e5a50b8287dbdc3fff36aaeacf0335ebc0c4f7a0aab58e
 
 # COPY *.mqsc /etc/mqm/

--- a/chart/base/values.yaml
+++ b/chart/base/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 name: qm-dev
-version: 9.2.2.0-r1
+version: 9.2.3.0-r1
 web:
   enabled: true
 


### PR DESCRIPTION
There is currently an issue with the 9.2.2.0-r1 MQ image with v1.5 Channel of the MQ operator.  Moving to this newer version will require v1.6 of the MQ Operator to be used. 