### PR TITLE
Updated licenses & versions to Operator 1.6 levels

### DIFF
--- a/chart/base/values.yaml
+++ b/chart/base/values.yaml
@@ -3,14 +3,18 @@
 # Declare variables to be passed into your templates.
 
 name: qm-dev
+# Acceptable versions available via https://www.ibm.com/docs/en/ibm-mq/9.2?topic=openshift-release-history-mq-operator
+# This field maps directly to queuemanager.spec.version
 version: 9.2.3.0-r1
 web:
   enabled: true
 
+# Acceptable license keys available via https://www.ibm.com/docs/en/ibm-mq/9.2?topic=mqibmcomv1beta1-licensing-reference
+# This field maps directly to queuemanager.spec.license
 license:
   accept: true
-  license: L-RJON-BN7PN3
-  halicense: L-RJON-BYRMYW
+  license: L-RJON-BZFQU2
+  halicense: L-RJON-BZFQU2
   use: NonProduction
 
 image:


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

Based on updates to the MQ Operator version and the underlying MQ QueueManager version, we needed to update the associated MQ QueueManager license string as well. I also added links to documentation for easier reference in the future.